### PR TITLE
[FIX] Problema en instalación

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,11 +101,11 @@ if os.name != 'nt':
 		get_python_lib(), sys.executable
 	)
 	# write script
-	f = open('planta', 'w')
+	f = open('planta.sh', 'w')
 	f.write(start_script)
 	f.close()
 	
-	script_files = ['planta']
+	script_files = ['planta.sh']
 else:
 	script_files = []
 


### PR DESCRIPTION
Al intentar escribir en Windows WSL, no admite generar un fichero planta con la carpeta Planta, por lo que se renombra a planta.sh